### PR TITLE
feat: Update buildspec to tag 'latest' for semantic releases only (DBTP-2088)

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -55,7 +55,7 @@ phases:
           docker tag $REPOSITORY_URI:$COMMIT_TAG "$REPOSITORY_URI:$TAG_LATEST";
         fi
         if [ "$SEMANTIC_LATEST" != "" ]; then
-          docker tag $REPOSITORY_URI:$COMMIT_TAG "$REPOSITORY_URI:SEMANTIC_LATEST";
+          docker tag $REPOSITORY_URI:$COMMIT_TAG "$REPOSITORY_URI:$SEMANTIC_LATEST";
         fi
       fi
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -28,6 +28,7 @@ phases:
         SEMVER_REGEX='^([0-9]+\.){2}[0-9]+$';
         if [[ $INCOMING_TAG =~ $SEMVER_REGEX ]]; then
           TAG_LATEST="tag-latest";
+          SEMANTIC_LATEST="latest"
         fi
       fi
     - >
@@ -35,23 +36,29 @@ phases:
       echo -e "\nBRANCH_TAG: $BRANCH_TAG"
       echo -e "\nTAG_TAG: $TAG_TAG"
       echo -e "\nTAG_LATEST: $TAG_LATEST"
+      echo -e "\nSEMANTIC_LATEST: $SEMANTIC_LATEST"
   build:
     commands:
     - echo Build started on `date`
     - echo Building the Docker image...
-    - docker build -t $REPOSITORY_URI .
-    - docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$COMMIT_TAG"
+    # - docker build -t $REPOSITORY_URI .    # adds 'latest' tag by default
+    - docker build -t $REPOSITORY_URI:$COMMIT_TAG .
+    
     - >
       if [ $BRANCH_TAG != "" ]; then
-        docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$BRANCH_TAG";
+        docker tag $REPOSITORY_URI:$COMMIT_TAG "$REPOSITORY_URI:$BRANCH_TAG";
       fi
     - >
       if [ $TAG_TAG != "" ]; then
-        docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$TAG_TAG";
+        docker tag $REPOSITORY_URI:$COMMIT_TAG "$REPOSITORY_URI:$TAG_TAG";
         if [ $TAG_LATEST != "" ]; then
-          docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$TAG_LATEST";
+          docker tag $REPOSITORY_URI:$COMMIT_TAG "$REPOSITORY_URI:$TAG_LATEST";
+        fi
+        if [ "$SEMANTIC_LATEST" != "" ]; then
+          docker tag $REPOSITORY_URI:$COMMIT_TAG "$REPOSITORY_URI:SEMANTIC_LATEST";
         fi
       fi
+
 
   post_build:
     commands:


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-2088.

- The issue we are seeing is that for Nginx buildspec, the current `docker build -t $REPOSITORY_URI .`  command adds tag latest to every image build by default, even for feature branches.

- We see from a search in UKtrade organisation that there are over 50 service teams that currently point their copilot Nginx sidecar value at `latest` (despite warnings it should be tag-latest)

- Testing a change on Nginx could easily break service teams set up. The codebuild trigger for the Nginx repo will build an image for any PUSH event. This would tag the feature branch with latest which is not desired as it may not be ready for production use.

- To correct the tag, you would need to pull down the previous correct latest image, retag it with latest and push it back up to ECR.

- PR ensures only semantic releases will be tagged with `latest` as well as `tag-latest`. For non-semantic releases (e.g. feature branches, development tags, or untagged pushes), the latest tag is not applied.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes any applicable changes to the documentation in this code base
- [x] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
